### PR TITLE
Add `namespace` and `freeze` options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,41 @@
 var isObject = require("isobject")
 
-function install(Vue) {
+var defaults = {
+  namespace: null,
+  freeze: false,
+}
+
+function install(Vue, options) {
+  // run once
   if (install.installed) return
   install.installed = true
 
+  // options
+  options = Object.assign({}, defaults, options)
+
   Vue.mixin({
     beforeCreate: function() {
-      var staticData = this.$options.staticData
-      if (typeof staticData === "function") staticData = staticData()
-      if (isObject(staticData)) Object.assign(this, staticData)
+      // data
+      var data = this.$options.staticData
+      if (typeof data === "function"){
+        data = data()
+      }
+
+      if (isObject(data)) {
+        // namespace
+        var target = this
+        if (options.namespace) {
+          this[options.namespace] = {}
+          target = this[options.namespace]
+        }
+
+        // assign
+        Object.keys(data).forEach(name => {
+          target[name] = options.freeze
+            ? Object.freeze(data[name])
+            : data[name]
+        })
+      }
     }
   })
 }

--- a/index.test.js
+++ b/index.test.js
@@ -1,59 +1,91 @@
 const { createLocalVue, mount } = require("@vue/test-utils")
 const VueStaticData = require("./index")
 
-const localVue = createLocalVue()
-const template = `
+describe("staticData", () => {
+  const localVue = createLocalVue()
+  const template = `
 <div>
   <p class="reactive" v-text="reactiveProp" />
   <p class="static" v-text="staticProp" />
 </div>
 `
+  const wrap = (staticData) => mount({
+    template,
+    data: () => ({
+      reactiveProp: "reactive",
+    }),
+    staticData,
+  }, {
+    localVue,
+  })
 
-const wrap = (staticData) => mount({
-  template,
-  data: () => ({
-    reactiveProp: "reactive"
-  }),
-  staticData
-}, {
-  localVue
+  localVue.use(VueStaticData)
+
+  const testStaticData = (name, staticData) => {
+    test(name, () => {
+      const wrapper = wrap(staticData)
+      const render = jest.spyOn(wrapper.vm, "_render")
+      const reactiveEl = wrapper.find(".reactive")
+      const staticEl = wrapper.find(".static")
+
+      expect(wrapper.isVueInstance()).toBeTruthy()
+      expect(reactiveEl.is("p")).toBeTruthy()
+      expect(staticEl.is("p")).toBeTruthy()
+
+      expect(reactiveEl.text()).toBe("reactive")
+      expect(staticEl.text()).toBe("static")
+
+      expect(render).toHaveBeenCalledTimes(0)
+
+      wrapper.vm.reactiveProp = "reactive updated"
+      wrapper.vm.staticProp = "static updated"
+
+      expect(render).toHaveBeenCalledTimes(1)
+
+      expect(reactiveEl.text()).toBe("reactive updated")
+      expect(staticEl.text()).toBe("static")
+
+      wrapper.vm.staticProp = "static updated again"
+      wrapper.vm.reactiveProp = "reactive updated again"
+
+      expect(render).toHaveBeenCalledTimes(2)
+
+      expect(reactiveEl.text()).toBe("reactive updated again")
+      expect(staticEl.text()).toBe("static updated again")
+    })
+  }
+
+  testStaticData("object", { staticProp: "static" })
+  testStaticData("function", () => ({ staticProp: "static" }))
 })
 
-localVue.use(VueStaticData)
-
-const testStaticData = (name, staticData) => {
-  test(name, () => {
-    const wrapper = wrap(staticData)
-    const render = jest.spyOn(wrapper.vm, "_render")
-    const reactiveEl = wrapper.find(".reactive")
-    const staticEl = wrapper.find(".static")
-
-    expect(wrapper.isVueInstance()).toBeTruthy()
-    expect(reactiveEl.is("p")).toBeTruthy()
-    expect(staticEl.is("p")).toBeTruthy()
-
-    expect(reactiveEl.text()).toBe("reactive")
-    expect(staticEl.text()).toBe("static")
-
-    expect(render).toHaveBeenCalledTimes(0)
-
-    wrapper.vm.reactiveProp = "reactive updated"
-    wrapper.vm.staticProp = "static updated"
-
-    expect(render).toHaveBeenCalledTimes(1)
-
-    expect(reactiveEl.text()).toBe("reactive updated")
-    expect(staticEl.text()).toBe("static")
-
-    wrapper.vm.staticProp = "static updated again"
-    wrapper.vm.reactiveProp = "reactive updated again"
-
-    expect(render).toHaveBeenCalledTimes(2)
-
-    expect(reactiveEl.text()).toBe("reactive updated again")
-    expect(staticEl.text()).toBe("static updated again")
+describe("options", () => {
+  const localVue = createLocalVue()
+  localVue.use(VueStaticData, {
+    namespace: "static",
+    freeze: true,
   })
-}
 
-testStaticData("staticData object", { staticProp: "static" })
-testStaticData("staticData function", () => ({ staticProp: "static" }))
+  const Status = {
+    accepted: "accepted",
+    rejected: "rejected",
+  }
+
+  const wrapper = mount({
+    template: "<div></div>",
+    staticData: {
+      Status,
+    },
+  }, {
+    localVue,
+  })
+
+  it("namespace", () => {
+    expect(wrapper.vm.static.Status.accepted).toBe("accepted")
+  })
+
+  it("freeze", () => {
+    wrapper.vm.static.Status.accepted = false
+    expect(wrapper.vm.static.Status.accepted).toBe("accepted")
+  })
+})

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,37 @@
 # Vue Static Data
 
+## Overview
+
 Add `staticData` to [Vue instances][vue-instances] and watch in awe as it does nothing.
 
-    yarn add vue-static-data
+
+## Setup
+
+Install with:
+
+```
+yarn add vue-static-data
+```
+
+Add and configure:
+
+```js
+import Vue from 'vue'
+import staticData from 'vue-static-data'
+
+Vue.use(staticData)
+```
+
+Configuration options:
+
+```js
+Vue.use(staticData, {
+  namespace: 'myData',  // a single string namespace to nest values under
+  freeze: true,         // a flag to freeze data, useful for enums
+})
+```
+
+## Usage
 
 ```vue
 <template>


### PR DESCRIPTION
This PR adds two new `options` to the plugin:

- `namespace` so data can optionally be namespaced to avoid clashes
- `freeze` to freeze objects (such as enums) so they cannot be modified

Have also added tests and updated the readme.

These features are taken from my [Vue Enums](https://github.com/davestewart/vue-enums) package (which I will deprecate) as it does essentially the same thing. The original features were in response to comments in the Vue Land Discord channel.